### PR TITLE
Feat/show own events (REQ1)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,18 @@
 class ApplicationController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  before_action :set_user
+
+  private
+
+  # Very basic, using the user's token as it's id
+  def authenticate
+    authenticate_or_request_with_http_token do |token, _options|
+      User.find_by(id: token)
+    end
+  end
+
+  def set_user
+    @user ||= authenticate
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,16 @@
 class EventsController < ApplicationController
+  def index
+    @events = get_user.events_ordered_by_from_date
+    render json: @events, status: :ok
+  end
+
+  private
+
+  def get_user
+    if params[:user_id].present?
+      User.find(params[:user_id])
+    else
+      @user
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
     member: 'member',
     owner: 'owner'
   }
+
+  def events_ordered_by_from_date
+    events.order('events.from_date ASC')
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EventsController, type: :controller do
 
     it "lists own events in chronological order" do
       event_1 = FactoryBot.create(:event, from_date: Date.yesterday)
-      event_2 = FactoryBot.create(:event, from_date: Date.today)
+      event_2 = FactoryBot.create(:event, from_date: Date.today, online: false, city: 'Santiago', country: 'CL')
       event_3 = FactoryBot.create(:event, from_date: Date.yesterday - 1, to_date: Date.yesterday)
       event_4 = FactoryBot.create(:event, from_date: Date.yesterday)
       participant_1 = FactoryBot.create(:event_participant, event: event_1, user:)
@@ -30,11 +30,23 @@ RSpec.describe EventsController, type: :controller do
       expect(DateTime.parse(resp[0]['from_date'])).to eq(event_3.from_date)
       expect(DateTime.parse(resp[1]['from_date'])).to eq(event_1.from_date)
       expect(DateTime.parse(resp[2]['from_date'])).to eq(event_2.from_date)
+      expect(resp[0]['online']).to eq(true)
+      expect(resp[1]['online']).to eq(true)
+      expect(resp[2]['online']).to eq(false)
+      expect(resp[0]['city']).to be_nil
+      expect(resp[1]['city']).to be_nil
+      expect(resp[2]['city']).to eq('Santiago')
+      expect(resp[0]['state']).to be_nil
+      expect(resp[1]['state']).to be_nil
+      expect(resp[2]['state']).to be_nil
+      expect(resp[0]['country']).to be_nil
+      expect(resp[1]['country']).to be_nil
+      expect(resp[2]['country']).to eq('CL')
     end
 
     it 'lists own events if no user_id provided' do
       event_1 = FactoryBot.create(:event, from_date: Date.yesterday)
-      event_2 = FactoryBot.create(:event, from_date: Date.today)
+      event_2 = FactoryBot.create(:event, from_date: Date.today, online: false, city: 'Santiago', country: 'CL')
       event_3 = FactoryBot.create(:event, from_date: Date.yesterday - 1, to_date: Date.yesterday)
       event_4 = FactoryBot.create(:event, from_date: Date.yesterday)
       participant_1 = FactoryBot.create(:event_participant, event: event_1, user:)
@@ -52,6 +64,18 @@ RSpec.describe EventsController, type: :controller do
       expect(DateTime.parse(resp[0]['from_date'])).to eq(event_3.from_date)
       expect(DateTime.parse(resp[1]['from_date'])).to eq(event_1.from_date)
       expect(DateTime.parse(resp[2]['from_date'])).to eq(event_2.from_date)
+      expect(resp[0]['online']).to eq(true)
+      expect(resp[1]['online']).to eq(true)
+      expect(resp[2]['online']).to eq(false)
+      expect(resp[0]['city']).to be_nil
+      expect(resp[1]['city']).to be_nil
+      expect(resp[2]['city']).to eq('Santiago')
+      expect(resp[0]['state']).to be_nil
+      expect(resp[1]['state']).to be_nil
+      expect(resp[2]['state']).to be_nil
+      expect(resp[0]['country']).to be_nil
+      expect(resp[1]['country']).to be_nil
+      expect(resp[2]['country']).to eq('CL')
     end
 
     it 'does not returns a list if no authentication provided' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe EventsController, type: :controller do
       expect(resp[0]['id']).to eq(event_3.id)
       expect(resp[1]['id']).to eq(event_1.id)
       expect(resp[2]['id']).to eq(event_2.id)
+      expect(DateTime.parse(resp[0]['from_date'])).to eq(event_3.from_date)
+      expect(DateTime.parse(resp[1]['from_date'])).to eq(event_1.from_date)
+      expect(DateTime.parse(resp[2]['from_date'])).to eq(event_2.from_date)
     end
 
     it 'lists own events if no user_id provided' do
@@ -46,6 +49,18 @@ RSpec.describe EventsController, type: :controller do
       expect(resp[0]['id']).to eq(event_3.id)
       expect(resp[1]['id']).to eq(event_1.id)
       expect(resp[2]['id']).to eq(event_2.id)
+      expect(DateTime.parse(resp[0]['from_date'])).to eq(event_3.from_date)
+      expect(DateTime.parse(resp[1]['from_date'])).to eq(event_1.from_date)
+      expect(DateTime.parse(resp[2]['from_date'])).to eq(event_2.from_date)
+    end
+
+    it 'does not returns a list if no authentication provided' do
+      event_1 = FactoryBot.create(:event, from_date: Date.yesterday)
+      event_4 = FactoryBot.create(:event, from_date: Date.yesterday)
+      participant_1 = FactoryBot.create(:event_participant, event: event_1, user:)
+      participant_4 = FactoryBot.create(:event_participant, event: event_4, user: owner)
+      get :index
+      expect(response).to have_http_status(:unauthorized)
     end
   end
   describe 'POST' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,4 +16,9 @@ FactoryBot.define do
     from_date { Faker::Time.between_dates(from: Date.today - 2, to: Date.today) }
     to_date { DateTime.now }
   end
+
+  factory :event_participant do
+    status { 'pending' }
+    role { 'participant' }
+  end
 end


### PR DESCRIPTION
Added endpoint for listing a user's own events in chronological order.
Added simple authentication by simply passing the user's id as it's bearer token.