### PR TITLE
Feat/create company events (REQ2)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,6 +7,9 @@ class EventsController < ApplicationController
 
   def create
     @event = Event.create!(**create_params)
+    user = get_user
+    EventParticipant.create!(user: @user, event: @event, role: 'creator')
+    EventParticipant.create!(user:, event: @event) if user != @user
     render json: @event, status: :created
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,13 @@
 class EventsController < ApplicationController
+  before_action :validate_participant, only: :create
   def index
     @events = get_user.events_ordered_by_from_date
     render json: @events, status: :ok
+  end
+
+  def create
+    @event = Event.create!(**create_params)
+    render json: @event, status: :created
   end
 
   private
@@ -12,5 +18,13 @@ class EventsController < ApplicationController
     else
       @user
     end
+  end
+
+  def create_params
+    params.permit(:name, :from_date, :to_date, :online, :city, :country, :state, :url)
+  end
+
+  def validate_participant
+    render status: :forbidden if @user.role != 'owner' || @user.company_id != get_user.company_id
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,3 +92,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+def authenticate(user)
+  "Token #{user.id}"
+end


### PR DESCRIPTION
Users with the owner role within a company can create events for members of their company.
If from a different company or not an owner, requests will return forbidden when trying to create said event.