### PR TITLE
Feat/show event conflict (REQ4)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :validate_participant, only: :create
   def index
     @events = get_user.events_ordered_by_from_date
-    render json: @events, status: :ok
+    render json: @events, include: { event_participants: { only: [:id, :user_id, :status, :role], methods: [:schedule_conflicts] } }, status: :ok
   end
 
   def create
@@ -10,7 +10,7 @@ class EventsController < ApplicationController
     user = get_user
     EventParticipant.create!(user: @user, event: @event, role: 'creator')
     EventParticipant.create!(user:, event: @event) if user != @user
-    render json: @event, status: :created
+    render json: @event, include: { event_participants: { only: [:id, :user_id, :status, :role], methods: [:schedule_conflicts] } },  status: :created
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,9 +3,4 @@ class Event < ApplicationRecord
   has_many :users, through: :event_participants
   validates :from_date, presence: true
   validates :to_date, presence: true
-
-  # Override the as_json method to include event_participants
-  def as_json(options = {})
-    super(options.merge(include: { event_participants: { only: [:id, :user_id, :status, :role] } }))
-  end
 end

--- a/app/models/event_participant.rb
+++ b/app/models/event_participant.rb
@@ -10,4 +10,8 @@ class EventParticipant < ApplicationRecord
     creator: 'creator',
     participant: 'participant'
   }, default: :participant
+
+  def schedule_conflicts
+    user.events.where('events.to_date >= ? AND events.from_date <= ?', event.from_date, event.to_date).where.not(id: event.id)
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -193,6 +193,51 @@ RSpec.describe EventsController, type: :controller do
       expect(owner.participations.count).to eq(0)
       expect(user.participations.count).to eq(0)
     end
+
+    it 'shows conflict of schedule on creation' do
+      event_1 = FactoryBot.create(:event, from_date: DateTime.parse('2024-11-18T13:00:00-03'), to_date: DateTime.parse('2024-11-18T14:00:00-03'))
+      FactoryBot.create(:event_participant, event: event_1, user: member)
+      request.headers['Authorization'] = authenticate(owner)
+      post :create,
+           params: {
+             user_id: member.id,
+             online: false,
+             country: 'CL',
+             city: 'Santiago',
+             from_date: '2024-11-18T13:30:00-03',
+             to_date: '2024-11-18T14:00:00-03'
+           },
+           as: :json
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body['event_participants'].length).to eq(2)
+      expect(body['event_participants'][0]['schedule_conflicts']).to eq([])
+      expect(body['event_participants'][1]['schedule_conflicts']).to eq([event_1.as_json])
+    end
+
+    it 'shows multiple conflicts of schedule on creation' do
+      event_1 = FactoryBot.create(:event, from_date: DateTime.parse('2024-11-18T13:00:00-03'), to_date: DateTime.parse('2024-11-18T14:00:00-03'))
+      event_2 = FactoryBot.create(:event, from_date: DateTime.parse('2024-11-18T11:00:00-03'), to_date: DateTime.parse('2024-11-18T15:00:00-03'))
+      FactoryBot.create(:event_participant, event: event_1, user: member)
+      FactoryBot.create(:event_participant, event: event_2, user: member)
+      FactoryBot.create(:event_participant, event: event_2, user: owner)
+      request.headers['Authorization'] = authenticate(owner)
+      post :create,
+           params: {
+             user_id: member.id,
+             online: false,
+             country: 'CL',
+             city: 'Santiago',
+             from_date: '2024-11-18T13:30:00-03',
+             to_date: '2024-11-18T14:00:00-03'
+           },
+           as: :json
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body['event_participants'].length).to eq(2)
+      expect(body['event_participants'][0]['schedule_conflicts']).to eq([event_2.as_json])
+      expect(body['event_participants'][1]['schedule_conflicts']).to match_array([event_1.as_json, event_2.as_json])
+    end
   end
   describe 'PATCH' do
 


### PR DESCRIPTION
When creating or listing an event, along with the participants of said event, the scheduling conflicts of each participant will also be shown (for the given event).
Refactor Event model to avoid overwriting `as_json`, instead using the `render` options to show participants and conflicts